### PR TITLE
Expect `pass` and `db` instead of `password` and `database`

### DIFF
--- a/machines/create-connection-url.js
+++ b/machines/create-connection-url.js
@@ -24,12 +24,12 @@ module.exports = {
       defaultsTo: '6379'
     },
 //
-    password: {
+    pass: {
       description: 'The password (if any) for the Redis server.',
       example: 'iheartredis'
     },
 //
-    database: {
+    db: {
       description: 'The index of the database to connect to.',
       example: 123
     }
@@ -54,8 +54,8 @@ module.exports = {
     var url = 'redis://';
 
     // Add the optional password.
-    if (inputs.password) {
-      url += ':' + inputs.password + '@';
+    if (inputs.pass) {
+      url += ':' + inputs.pass + '@';
     }
 
     // Add the host.
@@ -65,8 +65,8 @@ module.exports = {
     url += ':' + inputs.port;
 
     // Add the optional database.
-    if (inputs.database) {
-      url += '/' + inputs.database;
+    if (inputs.db) {
+      url += '/' + inputs.db;
     }
 
     // Return the finished URL through the "success" exit.

--- a/tests/create-connection-url.test.js
+++ b/tests/create-connection-url.test.js
@@ -30,8 +30,8 @@ describe('createConnectionUrl()', function (){
       var url = Pack.createConnectionUrl({
         host: 'redis2go.com',
         port: 6380,
-        password: 'secret',
-        database: 15
+        pass: 'secret',
+        db: 15
       }).execSync();
 
       assert.equal(url, 'redis://:secret@redis2go.com:6380/15');


### PR DESCRIPTION
This is consistent with what's in the docs for the session and sockets hooks.  See also https://github.com/balderdashy/sails/commit/aacc80b9db42fd71490bb3463ae669f356af6096

Currently using a password/db with socket.io-redis will fail in Sails 1.0 because of this mismatch.