### PR TITLE
Update pre-connection error catching to adjust for change in redis 2.8.0

### DIFF
--- a/machines/get-connection.js
+++ b/machines/get-connection.js
@@ -126,7 +126,7 @@ module.exports = {
     function onPreConnectionError (err){
       // If this is an authentication error (i.e. bad password), then
       // we won't be getting an `end` event, so we'll bail out immediately.
-      if (err.command === 'AUTH' && err.code === 'ERR') {
+      if (err.command === 'AUTH' && err.code === 'WRONGPASS') {
         client.removeListener('end', onPreConnectionEnd);
         client.removeListener('error', onPreConnectionError);
         // Swallow follow-on errors.


### PR DESCRIPTION
as of `redis 2.8.0` redis updated specific errors to have their own prefixes, including a -WRONGPASS error.